### PR TITLE
Respond with empty object if no credentials found

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,8 +37,10 @@ func main() {
 		wantedHost := svchost.Hostname(args[1])
 		token, ok := creds[wantedHost]
 		if !ok {
-			fmt.Fprintf(os.Stderr, "No credentials for %s are defined via environment variables.\n", svchost.ForDisplay(args[1]))
-			os.Exit(1)
+			// No stored credentials for a host is a non-error case; respond
+			// with an empty credentials object.
+			os.Stdout.WriteString("{}\n")
+			os.Exit(0)
 		}
 		result := resultJSON{token}
 		resultJSON, err := json.Marshal(result)


### PR DESCRIPTION
Missing credentials is a non-error case for a credentials helper, to ease the use of helpers with the public registry.

Fixes #1. Discussion at hashicorp/terraform#25938. Hope this is helpful; if not, please feel free to ignore or close.